### PR TITLE
Restore meta/metafy script installation

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -44,6 +44,7 @@ match    = cover_db
 [AutoPrereqs]
 
 [ExecDir]
+dir = script
 [ShareDir]
 
 [Keywords]


### PR DESCRIPTION
ExecDir defaults to installing executables from 'bin'.
Override it to install from 'script' instead.