### PR TITLE
Autogenerate minimum perl version using [MinimumPerlFast].

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -43,6 +43,7 @@ match    = cover_db
 [MetaYAML]
 [MetaJSON]
 [AutoPrereqs]
+[MinimumPerlFast]
 
 [ExecDir]
 dir = script


### PR DESCRIPTION
Hi @book 

I received the distribution as part of Pull Request Club members.
It was my monthly assignment for March 2022.

In the pull request, I propose a small trivial change i.e. auto generate minimum Perl version. It was suggested as Extra Issues (Kwalitee).

https://cpants.cpanauthors.org/release/BOOK/Acme-MetaSyntactic-1.015

Please review the change when you get spare moment.

Many Thanks.

Best Regards,
Mohammad